### PR TITLE
AAE-3038 allow external ACS and credentials

### DIFF
--- a/helm/alfresco-process-infrastructure/README.md
+++ b/helm/alfresco-process-infrastructure/README.md
@@ -88,7 +88,7 @@ Source code can be found [here](https://github.com/Alfresco/alfresco-process-inf
 | alfresco-infrastructure.nginx-ingress.enabled | bool | `false` |  |
 | alfresco-modeling-app.env.APP_CONFIG_AUTH_TYPE | string | `"OAUTH"` |  |
 | alfresco-modeling-app.env.APP_CONFIG_BPM_HOST | string | `"{{ include \"common.gateway-url\" . }}"` |  |
-| alfresco-modeling-app.env.APP_CONFIG_ECM_HOST | string | `"{{ include \"common.gateway-url\" . }}"` |  |
+| alfresco-modeling-app.env.APP_CONFIG_ECM_HOST | string | `"{{ template \"alfresco-process-infrastructure.acs-url\" . }}"` |  |
 | alfresco-modeling-app.env.APP_CONFIG_IDENTITY_HOST | string | `"{{ include \"common.keycloak-url\" . }}/admin/realms/{{ include \"common.keycloak-realm\" . }}"` |  |
 | alfresco-modeling-app.env.APP_CONFIG_OAUTH2_SILENT_LOGIN | string | `"true"` |  |
 | alfresco-modeling-app.image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -119,8 +119,10 @@ Source code can be found [here](https://github.com/Alfresco/alfresco-process-inf
 | alfresco-modeling-service.probePath | string | `"/actuator/health"` |  |
 | alfresco-modeling-service.rbac.create | bool | `false` |  |
 | alfresco-modeling-service.serviceAccount.create | bool | `false` |  |
-| global | object | `{"acs":{"host":"{{ template \"common.gateway-host\" . }}"},"gateway":{"annotations":{},"domain":"REPLACEME","host":"{{ template \"common.gateway-domain\" . }}","http":"false","tlsacme":"false"},"keycloak":{"host":"{{ template \"common.gateway-domain\" . }}","realm":"alfresco","resource":"activiti","url":""},"registryPullSecrets":["quay-registry-secret"]}` | for common values see https://github.com/Activiti/activiti-cloud-common-chart/blob/master/charts/common/README.md |
+| global | object | `{"acs":{"admin":{"password":"","username":""},"host":"{{ template \"common.gateway-host\" . }}","url":""},"gateway":{"annotations":{},"domain":"REPLACEME","host":"{{ template \"common.gateway-domain\" . }}","http":"false","tlsacme":"false"},"keycloak":{"host":"{{ template \"common.gateway-domain\" . }}","realm":"alfresco","resource":"activiti","url":""},"registryPullSecrets":["quay-registry-secret"]}` | for common values see https://github.com/Activiti/activiti-cloud-common-chart/blob/master/charts/common/README.md |
+| global.acs.admin | object | `{"password":"","username":""}` | admin credentials to setup required users/groups/acl on ACS |
 | global.acs.host | string | `"{{ template \"common.gateway-host\" . }}"` | host for content services |
+| global.acs.url | string | `""` | set full url to configure external ACS, https://acs.mydomain.com without /alfresco |
 | global.gateway.annotations | object | `{}` | Configure global annotations for all service ingresses |
 | global.gateway.domain | string | `"REPLACEME"` | Set to configure gateway domain template, i.e. {{ .Release.Namespace }}.1.3.4.5.nip.io  helm upgrade activiti . --install --set global.gateway.domain=1.2.3.4.nip.io |
 | global.gateway.host | string | `"{{ template \"common.gateway-domain\" . }}"` | Set to configure single host domain name for all services, i.e. "{{ .Release.Namespace }}.{{ template "common.gateway-domain" . }}" |

--- a/helm/alfresco-process-infrastructure/templates/_helpers.tpl
+++ b/helm/alfresco-process-infrastructure/templates/_helpers.tpl
@@ -46,7 +46,9 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{- define "alfresco-process-infrastructure.acs-url" -}}
-{{ template "common.gateway-proto" . }}://{{ template "alfresco-process-infrastructure.acs-host" . }}
+{{- $defaultValue := printf "%s://%s" (include "common.gateway-proto" .) (include "alfresco-process-infrastructure.acs-host" .) -}}
+{{- $value := default $defaultValue .Values.global.acs.url -}}
+{{- tpl (printf "%s" $value) . -}}
 {{- end -}}
 
 {{- define "alfresco-process-infrastructure.ads-registry-secret" }}

--- a/helm/alfresco-process-infrastructure/templates/setup-acs-script-job.yaml
+++ b/helm/alfresco-process-infrastructure/templates/setup-acs-script-job.yaml
@@ -28,6 +28,10 @@ spec:
           env:
             - name: "GATEWAY_URL"
               value: {{ template "alfresco-process-infrastructure.acs-url" . }}
+            - name: "REPOSITORY_ADMIN_USER"
+              value: {{ .Values.global.acs.admin.username | quote }}
+            - name: "REPOSITORY_ADMIN_PASSWORD"
+              value: {{ .Values.global.acs.admin.password | quote }}
           volumeMounts:
             - name: config
               mountPath: /tmp/init

--- a/helm/alfresco-process-infrastructure/values.yaml
+++ b/helm/alfresco-process-infrastructure/values.yaml
@@ -43,6 +43,13 @@ global:
     # global.acs.host -- host for content services
     host: '{{ template "common.gateway-host" . }}'
 
+    # global.acs.url -- set full url to configure external ACS, https://acs.mydomain.com without /alfresco
+    url: ""
+    # global.acs.admin -- admin credentials to setup required users/groups/acl on ACS
+    admin:
+      username: ""
+      password: ""
+
 alfresco-infrastructure:
   nginx-ingress:
     enabled: false
@@ -173,7 +180,7 @@ alfresco-modeling-app:
   env:
     APP_CONFIG_AUTH_TYPE: "OAUTH"
     APP_CONFIG_OAUTH2_SILENT_LOGIN: "true"
-    APP_CONFIG_ECM_HOST: '{{ include "common.gateway-url" . }}'
+    APP_CONFIG_ECM_HOST: '{{ template "alfresco-process-infrastructure.acs-url" . }}'
     APP_CONFIG_BPM_HOST: '{{ include "common.gateway-url" . }}'
     APP_CONFIG_IDENTITY_HOST: '{{ include "common.keycloak-url" . }}/admin/realms/{{ include "common.keycloak-realm" . }}'
 


### PR DESCRIPTION
allows the configuration of the ACS URL without the /alfresco prefix as external with a default value in global plus admin username and password