### PR TITLE
AAE-5572 Bump up Tika version to 2.5.3

### DIFF
--- a/helm/alfresco-process-infrastructure/README.md
+++ b/helm/alfresco-process-infrastructure/README.md
@@ -362,7 +362,7 @@ Kubernetes: `>=1.15.0-0`
 | alfresco-modeling-service.rabbitmq.enabled | bool | `false` |  |
 | alfresco-tika-service.enabled | bool | `true` |  |
 | alfresco-tika-service.image.repository | string | `"alfresco/alfresco-tika"` |  |
-| alfresco-tika-service.image.tag | string | `"2.3.6"` |  |
+| alfresco-tika-service.image.tag | string | `"2.5.3"` |  |
 | alfresco-tika-service.ingress.enabled | bool | `false` |  |
 | alfresco-tika-service.javaOpts.other | string | `"-XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80"` |  |
 | alfresco-tika-service.livenessProbe.path | string | `"/live"` |  |

--- a/helm/alfresco-process-infrastructure/values.yaml
+++ b/helm/alfresco-process-infrastructure/values.yaml
@@ -792,7 +792,7 @@ alfresco-tika-service:
   enabled: true
   image:
     repository: alfresco/alfresco-tika
-    tag: 2.3.6
+    tag: 2.5.3
   service:
     name: tika
     internalPort: 8090


### PR DESCRIPTION
Addressing: AAE-5572
At the moment of addressing this task, the latest version of Tika was: [2.5.3](https://hub.docker.com/layers/alfresco/alfresco-tika/2.5.3/images/sha256-3d595bf168a631875258307bc397674cf49194499c4f4d26046b1984dd0c61df?context=explore)