### PR TITLE
OPSEXP-971 update RabbitMQ chart for K8S 1.20

### DIFF
--- a/helm/alfresco-process-infrastructure/README.md
+++ b/helm/alfresco-process-infrastructure/README.md
@@ -23,7 +23,7 @@ Kubernetes: `>=1.15.0-0`
 | https://activiti.github.io/activiti-cloud-helm-charts | alfresco-deployment-service(common) | 7.1.0-M14 |
 | https://activiti.github.io/activiti-cloud-helm-charts | alfresco-tika-service(common) | 7.1.0-M14 |
 | https://charts.bitnami.com/bitnami | postgresql | 9.1.1 |
-| https://charts.bitnami.com/bitnami | rabbitmq | 7.8.0 |
+| https://charts.bitnami.com/bitnami | rabbitmq | 8.20.5 |
 | https://kubernetes-charts.alfresco.com/stable | alfresco-identity-service | 4.0.0 |
 
 ## Values

--- a/helm/alfresco-process-infrastructure/requirements.yaml
+++ b/helm/alfresco-process-infrastructure/requirements.yaml
@@ -17,7 +17,7 @@ dependencies:
     condition: postgresql.enabled
   - name: rabbitmq
     repository: https://charts.bitnami.com/bitnami
-    version: 7.8.0
+    version: 8.20.5
     condition: rabbitmq.enabled
   - name: common
     repository: https://activiti.github.io/activiti-cloud-helm-charts


### PR DESCRIPTION
Current RabbitMQ chart is not compatible with k8s 1.20 and needs to be updated

Ref. OPSEXP-971