### PR TITLE
OPSEXP-1344 Fix bitnami shell image name

### DIFF
--- a/helm/alfresco-process-infrastructure/README.md
+++ b/helm/alfresco-process-infrastructure/README.md
@@ -430,7 +430,7 @@ Kubernetes: `>=1.15.0-0`
 | rabbitmq.resources.limits.memory | string | `"1500Mi"` |  |
 | rabbitmq.resources.requests.memory | string | `"1500Mi"` |  |
 | setup-acs-script-job.enabled | bool | `true` |  |
-| setup-acs-script-job.image.repository | string | `"bitnami/shell"` |  |
+| setup-acs-script-job.image.repository | string | `"bitnami/bitnami-shell"` |  |
 | setup-acs-script-job.image.tag | int | `10` |  |
 | setup-acs-script-job.loadTestData | bool | `true` |  |
 

--- a/helm/alfresco-process-infrastructure/values.yaml
+++ b/helm/alfresco-process-infrastructure/values.yaml
@@ -794,7 +794,7 @@ setup-acs-script-job:
   enabled: true
   loadTestData: true
   image:
-    repository: bitnami/shell
+    repository: bitnami/bitnami-shell
     tag: 10
 alfresco-tika-service:
   nameOverride: alfresco-tika-service


### PR DESCRIPTION
Fixup for OPSEXP-1344

```
~/s/a/t/e/eks ❯❯❯ docker pull bitnami/shell:10
Error response from daemon: pull access denied for bitnami/shell, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
~/s/a/t/e/eks ❯❯❯ docker pull bitnami/bitnami-shell:10
10: Pulling from bitnami/bitnami-shell
fea43f71b0b0: Pull complete
82597b26ab90: Pull complete
1fba8bc860b6: Pull complete
9f644f650f56: Pull complete
Digest: sha256:d10521ec3dbe9082332e0dc41402e5fa89f2c3b27463e37d62617b5ad95c1785
Status: Downloaded newer image for bitnami/bitnami-shell:10
docker.io/bitnami/bitnami-shell:10
~/s/a/t/e/eks ❯❯❯ docker run --rm -it bitnami/bitnami-shell:10
root@2cb77ffadf12:/# curl
curl: try 'curl --help' or 'curl --manual' for more information
root@2cb77ffadf12:/# exit
```