### PR TITLE
AAE-9367 trigger auto-merge workflow also on PR labeled

### DIFF
--- a/.github/workflows/versions-propagation-auto-merge.yml
+++ b/.github/workflows/versions-propagation-auto-merge.yml
@@ -1,5 +1,10 @@
 name: Versions propagation auto-merge
-on: pull_request
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - labeled
 
 jobs:
   enable-auto-merge:

--- a/.github/workflows/versions-propagation-auto-merge.yml
+++ b/.github/workflows/versions-propagation-auto-merge.yml
@@ -1,10 +1,9 @@
 name: Versions propagation auto-merge
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - labeled
+    types: [opened, reopened, labeled]
+    branches:
+      - develop
 
 jobs:
   enable-auto-merge:


### PR DESCRIPTION
Even if the label is added in the same command as the PR creation, it seems that it's actually added in a second step. As consequence, in some cases, the auto-merge workflow is skipped because the label is not there yet.

This PR is updating the workflow to be triggered also when a label is added to the PR.