### PR TITLE
HXOR-474 Replace minideb image with rockylinux

### DIFF
--- a/helm/alfresco-process-infrastructure/README.md
+++ b/helm/alfresco-process-infrastructure/README.md
@@ -571,6 +571,6 @@ Kubernetes: `>=1.15.0-0`
 | rabbitmq.resources.limits.memory | string | `"1500Mi"` |  |
 | rabbitmq.resources.requests.memory | string | `"1500Mi"` |  |
 | setup-acs-script-job.enabled | bool | `true` |  |
-| setup-acs-script-job.image.repository | string | `"bitnami/minideb-extras"` |  |
-| setup-acs-script-job.image.tag | string | `"stretch"` |  |
+| setup-acs-script-job.image.repository | string | `"rockylinux/rockylinux"` |  |
+| setup-acs-script-job.image.tag | string | `"9-minimal"` |  |
 | setup-acs-script-job.loadTestData | bool | `true` |  |

--- a/helm/alfresco-process-infrastructure/values.yaml
+++ b/helm/alfresco-process-infrastructure/values.yaml
@@ -925,8 +925,8 @@ setup-acs-script-job:
   enabled: true
   loadTestData: true
   image:
-    repository: bitnami/minideb-extras
-    tag: stretch
+    repository: rockylinux/rockylinux
+    tag: 9-minimal
 alfresco-tika-service:
   nameOverride: alfresco-tika-service
   enabled: true


### PR DESCRIPTION
See HXOR-474 the minideb-extras image has been deprecated and no longer available in docker hub, replacing with rockylinux mininal which meets the same requirements of being multi platform and having curl and bash as preinstalled packages