### PR TITLE
HXOR-323: ACS: Fail fast on API errors, with basic logging

### DIFF
--- a/helm/alfresco-process-infrastructure/functions_acs.sh
+++ b/helm/alfresco-process-infrastructure/functions_acs.sh
@@ -8,8 +8,7 @@ REPOSITORY_ADMIN_PASSWORD=${REPOSITORY_ADMIN_PASSWORD:-admin}
 # 5 min timeout
 echo "connecting to ${REPOSITORY_URL}"
 COUNTER=0
-while [[ "$(curl -s -o /dev/null -w '%{http_code}' "${REPOSITORY_URL}/api/-default-/public/alfresco/versions/1/probes/-ready-")" != "200" ]]
-do
+while ! curl --fail -s -o /dev/null "${REPOSITORY_URL}/api/-default-/public/alfresco/versions/1/probes/-ready-"; do
   echo "."
   sleep 5
 

--- a/helm/alfresco-process-infrastructure/functions_acs.sh
+++ b/helm/alfresco-process-infrastructure/functions_acs.sh
@@ -8,11 +8,11 @@ REPOSITORY_ADMIN_PASSWORD=${REPOSITORY_ADMIN_PASSWORD:-admin}
 # 5 min timeout
 echo "connecting to ${REPOSITORY_URL}"
 COUNTER=0
-while [[ $COUNTER -lt 300 && "$(curl -s -o /dev/null -w '%{http_code}' ${REPOSITORY_URL}/api/-default-/public/alfresco/versions/1/probes/-ready-)" != "200" ]]
+while [[ $COUNTER -lt 300 && "$(curl -s -o /dev/null -w '%{http_code}' "${REPOSITORY_URL}/api/-default-/public/alfresco/versions/1/probes/-ready-")" != "200" ]]
 do
   echo "."
   sleep 5
-  let COUNTER=COUNTER+1
+  (( ++COUNTER ))
 done
 echo "connection OK"
 
@@ -24,7 +24,7 @@ create_user() {
 
   curl -X POST \
     --header 'Content-Type: application/json' --header 'Accept: application/json' \
-    --user ${REPOSITORY_ADMIN_USER}:${REPOSITORY_ADMIN_PASSWORD} \
+    --user "${REPOSITORY_ADMIN_USER}:${REPOSITORY_ADMIN_PASSWORD}" \
     -d "{
     \"id\": \"${ACS_USER}\",
     \"firstName\": \"${ACS_USER}\",
@@ -42,7 +42,7 @@ create_group() {
 
   curl -X POST \
     --header 'Content-Type: application/json' --header 'Accept: application/json' \
-    --user ${REPOSITORY_ADMIN_USER}:${REPOSITORY_ADMIN_PASSWORD} \
+    --user "${REPOSITORY_ADMIN_USER}:${REPOSITORY_ADMIN_PASSWORD}" \
     -d "{
     \"id\": \"GROUP_${ACS_GROUP}\"
   }" "${REPOSITORY_URL}/api/-default-/public/alfresco/versions/1/groups"
@@ -61,7 +61,7 @@ add_user_to_group() {
 
   curl -X POST \
     --header 'Content-Type: application/json' --header 'Accept: application/json' \
-    --user ${REPOSITORY_ADMIN_USER}:${REPOSITORY_ADMIN_PASSWORD} \
+    --user "${REPOSITORY_ADMIN_USER}:${REPOSITORY_ADMIN_PASSWORD}" \
     -d "{
     \"id\": \"${ACS_USER}\",
     \"memberType\": \"PERSON\"

--- a/helm/alfresco-process-infrastructure/functions_acs.sh
+++ b/helm/alfresco-process-infrastructure/functions_acs.sh
@@ -8,11 +8,16 @@ REPOSITORY_ADMIN_PASSWORD=${REPOSITORY_ADMIN_PASSWORD:-admin}
 # 5 min timeout
 echo "connecting to ${REPOSITORY_URL}"
 COUNTER=0
-while [[ $COUNTER -lt 300 && "$(curl -s -o /dev/null -w '%{http_code}' "${REPOSITORY_URL}/api/-default-/public/alfresco/versions/1/probes/-ready-")" != "200" ]]
+while [[ "$(curl -s -o /dev/null -w '%{http_code}' "${REPOSITORY_URL}/api/-default-/public/alfresco/versions/1/probes/-ready-")" != "200" ]]
 do
   echo "."
   sleep 5
+
   (( ++COUNTER ))
+  if [ $COUNTER -ge 300 ]; then
+    echo "repository unavailable"
+    exit 1
+  fi
 done
 echo "connection OK"
 

--- a/helm/alfresco-process-infrastructure/functions_acs.sh
+++ b/helm/alfresco-process-infrastructure/functions_acs.sh
@@ -14,7 +14,7 @@ do
   sleep 5
 
   (( ++COUNTER ))
-  if [ $COUNTER -ge 300 ]; then
+  if [ $COUNTER -ge 60 ]; then
     echo "repository unavailable"
     exit 1
   fi

--- a/helm/alfresco-process-infrastructure/functions_acs.sh
+++ b/helm/alfresco-process-infrastructure/functions_acs.sh
@@ -22,7 +22,7 @@ create_user() {
   local ACS_PASSWORD="${3:-password}"
   echo "create user ${ACS_USER}"
 
-  curl -X POST \
+  curl --fail -X POST \
     --header 'Content-Type: application/json' --header 'Accept: application/json' \
     --user "${REPOSITORY_ADMIN_USER}:${REPOSITORY_ADMIN_PASSWORD}" \
     -d "{
@@ -31,7 +31,8 @@ create_user() {
     \"lastName\": \"User\",
     \"email\": \"${ACS_EMAIL}\",
     \"password\": \"${ACS_PASSWORD}\"
-  }" "${REPOSITORY_URL}/api/-default-/public/alfresco/versions/1/people"
+  }" "${REPOSITORY_URL}/api/-default-/public/alfresco/versions/1/people" \
+  || { echo "cannot create user ${ACS_USER}"; exit 1; }
 
   echo
 }
@@ -40,12 +41,13 @@ create_group() {
   local ACS_GROUP="$1";
   echo "create group ${ACS_GROUP}"
 
-  curl -X POST \
+  curl --fail -X POST \
     --header 'Content-Type: application/json' --header 'Accept: application/json' \
     --user "${REPOSITORY_ADMIN_USER}:${REPOSITORY_ADMIN_PASSWORD}" \
     -d "{
     \"id\": \"GROUP_${ACS_GROUP}\"
-  }" "${REPOSITORY_URL}/api/-default-/public/alfresco/versions/1/groups"
+  }" "${REPOSITORY_URL}/api/-default-/public/alfresco/versions/1/groups" \
+  || { echo "cannot create group ${ACS_GROUP}"; exit 1; }
 
   echo
 }
@@ -59,13 +61,14 @@ add_user_to_group() {
   local ACS_USER="$1" ACS_GROUP="$2";
   echo "add user ${ACS_USER} to group ${ACS_GROUP}"
 
-  curl -X POST \
+  curl --fail -X POST \
     --header 'Content-Type: application/json' --header 'Accept: application/json' \
     --user "${REPOSITORY_ADMIN_USER}:${REPOSITORY_ADMIN_PASSWORD}" \
     -d "{
     \"id\": \"${ACS_USER}\",
     \"memberType\": \"PERSON\"
-  }" "${REPOSITORY_URL}/api/-default-/public/alfresco/versions/1/groups/GROUP_${ACS_GROUP}/members"
+  }" "${REPOSITORY_URL}/api/-default-/public/alfresco/versions/1/groups/GROUP_${ACS_GROUP}/members" \
+  || { echo "cannot add user ${ACS_USER} to group ${ACS_GROUP}"; exit 1; }
 
   echo
 }

--- a/helm/alfresco-process-infrastructure/setup_acs.sh
+++ b/helm/alfresco-process-infrastructure/setup_acs.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-source $(dirname "$0")/functions_acs.sh
+set -euo pipefail
+source "$(dirname "$0")/functions_acs.sh"
 
-create_user "service-account-storage-service" "service-account-storage-service@example.com" $(generate_alfpwd)
+create_user "service-account-storage-service" "service-account-storage-service@example.com" "$(generate_alfpwd)"
 add_user_to_group "service-account-storage-service" "ALFRESCO_ADMINISTRATORS"
 
 if [[ "$LOAD_TEST_DATA" == "true" ]]


### PR DESCRIPTION
Ref. HXOR-323

- Enable `set -euo pipefail` in ACS scripts.
- Resolve warnings reported by `shellcheck`.
- Fail fast on API errors in user/group management.