### PR TITLE
AAE-17130 fix pod labels indent level

### DIFF
--- a/helm/alfresco-process-infrastructure/README.md
+++ b/helm/alfresco-process-infrastructure/README.md
@@ -537,10 +537,10 @@ Kubernetes: `>=1.15.0-0`
 | alfresco-tika-service.livenessProbe.path | string | `"/live"` |  |
 | alfresco-tika-service.nameOverride | string | `"alfresco-tika-service"` |  |
 | alfresco-tika-service.podAnnotations."admission.datadoghq.com/java-lib.version" | string | `"{{ include \"alfresco-process-infrastructure.datadog.agent.javaLibVersion\" . }}"` |  |
-| alfresco-tika-service.podAnnotations.podLabels."admission.datadoghq.com/enabled" | string | `"{{ include \"alfresco-process-infrastructure.datadog.agent.admission\" . }}"` |  |
-| alfresco-tika-service.podAnnotations.podLabels."tags.datadoghq.com/env" | string | `"{{ include \"alfresco-process-infrastructure.datadog.env\" . }}"` |  |
-| alfresco-tika-service.podAnnotations.podLabels."tags.datadoghq.com/service" | string | `"{{ .Chart.Name }}"` |  |
-| alfresco-tika-service.podAnnotations.podLabels."tags.datadoghq.com/version" | string | `"{{ .Values.image.tag }}"` |  |
+| alfresco-tika-service.podLabels."admission.datadoghq.com/enabled" | string | `"{{ include \"alfresco-process-infrastructure.datadog.agent.admission\" . }}"` |  |
+| alfresco-tika-service.podLabels."tags.datadoghq.com/env" | string | `"{{ include \"alfresco-process-infrastructure.datadog.env\" . }}"` |  |
+| alfresco-tika-service.podLabels."tags.datadoghq.com/service" | string | `"{{ .Chart.Name }}"` |  |
+| alfresco-tika-service.podLabels."tags.datadoghq.com/version" | string | `"{{ .Values.image.tag }}"` |  |
 | alfresco-tika-service.readinessProbe.path | string | `"/ready"` |  |
 | alfresco-tika-service.resources.limits.memory | string | `"1000Mi"` |  |
 | alfresco-tika-service.resources.requests.memory | string | `"1000Mi"` |  |

--- a/helm/alfresco-process-infrastructure/values.yaml
+++ b/helm/alfresco-process-infrastructure/values.yaml
@@ -1165,11 +1165,11 @@ alfresco-tika-service:
   nameOverride: alfresco-tika-service
   podAnnotations:
     admission.datadoghq.com/java-lib.version: '{{ include "alfresco-process-infrastructure.datadog.agent.javaLibVersion" . }}'
-    podLabels:
-      admission.datadoghq.com/enabled: '{{ include "alfresco-process-infrastructure.datadog.agent.admission" . }}'
-      tags.datadoghq.com/service: "{{ .Chart.Name }}"
-      tags.datadoghq.com/env: '{{ include "alfresco-process-infrastructure.datadog.env" . }}'
-      tags.datadoghq.com/version: "{{ .Values.image.tag }}"
+  podLabels:
+    admission.datadoghq.com/enabled: '{{ include "alfresco-process-infrastructure.datadog.agent.admission" . }}'
+    tags.datadoghq.com/service: "{{ .Chart.Name }}"
+    tags.datadoghq.com/env: '{{ include "alfresco-process-infrastructure.datadog.env" . }}'
+    tags.datadoghq.com/version: "{{ .Values.image.tag }}"
   enabled: true
   image:
     repository: quay.io/alfresco/alfresco-process-tika


### PR DESCRIPTION
The wrong indentation seems to be the root cause of
```
        Deployment in version "v1" cannot be handled as a
        Deployment: json: cannot unmarshal object into Go struct field
        ObjectMeta.spec.template.metadata.annotations of type string
```