### PR TITLE
AAE-22224 Pre-commit fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,6 @@ jobs:
         uses: Alfresco/alfresco-build-tools/.github/actions/setup-kubepug@553490b6434e1ec43ced9b321a04fadb91535d4c # v5.25.0
       - name: pre-commit
         uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@553490b6434e1ec43ced9b321a04fadb91535d4c # v5.25.0
-        with:
-          skip_checkout: true
       - name: Run Checkov
         uses: bridgecrewio/checkov-action@e1bb78184f5dd3690fb1089d6c4f51295f9dff48 # v12.1839.0
         with:

--- a/README.md
+++ b/README.md
@@ -273,3 +273,5 @@ Requires the following secrets to be set:
 | RANCHER2_ACCESS_KEY           | Rancher access key                   |
 | RANCHER2_SECRET_KEY           | Rancher secret key                   |
 | SLACK_NOTIFICATION_BOT_TOKEN  | Token to notify slack on failure     |
+
+test

--- a/README.md
+++ b/README.md
@@ -273,5 +273,3 @@ Requires the following secrets to be set:
 | RANCHER2_ACCESS_KEY           | Rancher access key                   |
 | RANCHER2_SECRET_KEY           | Rancher secret key                   |
 | SLACK_NOTIFICATION_BOT_TOKEN  | Token to notify slack on failure     |
-
-test


### PR DESCRIPTION
Fixes pre-commit issue that started happening recently:
```
Validate Dependabot Config...............................................Failed
- hook id: check-jsonschema
- exit code: 1
Error: Unexpected Error building schema validator
FailedDownloadError: got responses with status=503, retries exhausted
  in "/home/runner/.cache/pre-commit/repojq8yxjij/py_env-python3.9/lib/python3.9/site-packages/check_jsonschema/checker.py", line 48
  >>> return self._schema_loader.get_validator(filename, doc, self._format_opts)
```
e.g. here: https://github.com/Alfresco/alfresco-process-infrastructure-deployment/actions/runs/8999362112/job/24722588766#logs