### PR TITLE
AAE-24037 Adjust studio account level apps memory requests

### DIFF
--- a/helm/alfresco-process-infrastructure/README.md
+++ b/helm/alfresco-process-infrastructure/README.md
@@ -133,9 +133,9 @@ Kubernetes: `>=1.15.0-0`
 | alfresco-deployment-service.readinessProbe.path | string | `"{{ .Values.ingress.path }}/actuator/health/readiness"` |  |
 | alfresco-deployment-service.replicaCount | int | `2` |  |
 | alfresco-deployment-service.resources.limits.cpu | string | `"1000m"` |  |
-| alfresco-deployment-service.resources.limits.memory | string | `"2000Mi"` |  |
+| alfresco-deployment-service.resources.limits.memory | string | `"2525Mi"` |  |
 | alfresco-deployment-service.resources.requests.cpu | string | `"300m"` |  |
-| alfresco-deployment-service.resources.requests.memory | string | `"1000Mi"` |  |
+| alfresco-deployment-service.resources.requests.memory | string | `"1175Mi"` |  |
 | alfresco-identity-adapter-service.activiti.keycloak.clientId | string | `"{{ .Values.global.keycloak.clientId }}"` |  |
 | alfresco-identity-adapter-service.activiti.keycloak.clientSecret | string | `"{{ .Values.global.keycloak.clientSecret }}"` |  |
 | alfresco-identity-adapter-service.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels."app.kubernetes.io/instance" | string | `"{{ .Release.Name }}"` |  |
@@ -168,6 +168,10 @@ Kubernetes: `>=1.15.0-0`
 | alfresco-identity-adapter-service.probePath | string | `"/actuator/health"` |  |
 | alfresco-identity-adapter-service.rabbitmq.enabled | bool | `false` |  |
 | alfresco-identity-adapter-service.replicaCount | int | `2` |  |
+| alfresco-identity-adapter-service.resources.limits.cpu | string | `"750m"` |  |
+| alfresco-identity-adapter-service.resources.limits.memory | string | `"3000Mi"` |  |
+| alfresco-identity-adapter-service.resources.requests.cpu | string | `"150m"` |  |
+| alfresco-identity-adapter-service.resources.requests.memory | string | `"905Mi"` |  |
 | alfresco-identity-service.command[0] | string | `"/opt/keycloak/bin/kc.sh"` |  |
 | alfresco-identity-service.command[1] | string | `"start"` |  |
 | alfresco-identity-service.command[2] | string | `"--http-enabled=true"` |  |
@@ -502,7 +506,7 @@ Kubernetes: `>=1.15.0-0`
 | alfresco-modeling-service.resources.limits.cpu | string | `"2500m"` |  |
 | alfresco-modeling-service.resources.limits.memory | string | `"2000Mi"` |  |
 | alfresco-modeling-service.resources.requests.cpu | string | `"1000m"` |  |
-| alfresco-modeling-service.resources.requests.memory | string | `"1000Mi"` |  |
+| alfresco-modeling-service.resources.requests.memory | string | `"1150Mi"` |  |
 | alfresco-process-analytics-playground.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels."app.kubernetes.io/instance" | string | `"{{ .Release.Name }}"` |  |
 | alfresco-process-analytics-playground.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels."app.kubernetes.io/name" | string | `"{{ template \"common.name\" . }}"` |  |
 | alfresco-process-analytics-playground.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey | string | `"failure-domain.beta.kubernetes.io/zone"` |  |

--- a/helm/alfresco-process-infrastructure/values.yaml
+++ b/helm/alfresco-process-infrastructure/values.yaml
@@ -691,7 +691,7 @@ alfresco-modeling-service:
       memory: 2000Mi
     requests:
       cpu: 1000m
-      memory: 1000Mi
+      memory: 1150Mi
 alfresco-modeling-app:
   enabled: true
   nameOverride: alfresco-modeling-app
@@ -1148,10 +1148,10 @@ alfresco-deployment-service:
   resources:
     limits:
       cpu: 1000m
-      memory: 2000Mi
+      memory: 2525Mi
     requests:
       cpu: 300m
-      memory: 1000Mi
+      memory: 1175Mi
 alfresco-admin-app:
   enabled: true
   nameOverride: alfresco-admin-app
@@ -1691,6 +1691,13 @@ alfresco-identity-adapter-service:
     xmx: 3072m
     other: >-
       -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true -XX:+UseZGC -XX:+ZGenerational -XX:MinHeapFreeRatio=5 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+  resources:
+    requests:
+      memory: 905Mi
+      cpu: 150m
+    limits:
+      cpu: 750m
+      memory: 3000Mi
 alfresco-static-resources:
   nameOverride: alfresco-static-resources
   podAnnotations:


### PR DESCRIPTION
Following https://github.com/Alfresco/hxp-studio-services/pull/2699:
Adjusting memory requests and limits to higher consumption as observed in Datadog. The increase in requests is mainly due to introduction of Generational ZGC + 15% added to account for memory consumption when the app is used. The limits have been adjusted accordingly to the increase in requests.