### PR TITLE
AAE-30755 Fix Analytics Playground session management error

### DIFF
--- a/helm/alfresco-process-infrastructure/README.md
+++ b/helm/alfresco-process-infrastructure/README.md
@@ -526,7 +526,11 @@ Kubernetes: `>=1.15.0-0`
 | alfresco-process-analytics-playground.image.pullPolicy | string | `"Always"` |  |
 | alfresco-process-analytics-playground.image.repository | string | `"quay.io/alfresco/alfresco-process-analytics-graphql-playground"` |  |
 | alfresco-process-analytics-playground.image.tag | string | `"7.19.0-alpha.263"` |  |
+| alfresco-process-analytics-playground.ingress.annotations."nginx.ingress.kubernetes.io/affinity" | string | `"cookie"` |  |
 | alfresco-process-analytics-playground.ingress.annotations."nginx.ingress.kubernetes.io/enable-cors" | string | `"true"` |  |
+| alfresco-process-analytics-playground.ingress.annotations."nginx.ingress.kubernetes.io/session-cookie-expires" | string | `"172800"` |  |
+| alfresco-process-analytics-playground.ingress.annotations."nginx.ingress.kubernetes.io/session-cookie-max-age" | string | `"172800"` |  |
+| alfresco-process-analytics-playground.ingress.annotations."nginx.ingress.kubernetes.io/session-cookie-name" | string | `"analytics-playground"` |  |
 | alfresco-process-analytics-playground.ingress.className | string | `"nginx"` |  |
 | alfresco-process-analytics-playground.ingress.enabled | bool | `true` |  |
 | alfresco-process-analytics-playground.ingress.path | string | `"/analytics/playground/"` |  |

--- a/helm/alfresco-process-infrastructure/values.yaml
+++ b/helm/alfresco-process-infrastructure/values.yaml
@@ -1549,6 +1549,10 @@ alfresco-process-analytics-playground:
     className: nginx
     annotations:
       nginx.ingress.kubernetes.io/enable-cors: "true"
+      nginx.ingress.kubernetes.io/affinity: cookie
+      nginx.ingress.kubernetes.io/session-cookie-expires: '172800'
+      nginx.ingress.kubernetes.io/session-cookie-max-age: '172800'
+      nginx.ingress.kubernetes.io/session-cookie-name: analytics-playground
   resources:
     limits:
       cpu: 1000m


### PR DESCRIPTION
caused by not sticking ingress to the application backend

https://hyland.atlassian.net/browse/AAE-30755

Added sticky session directives to the analytics playground ingress to pin the user session to specific pod when running multiple replicas
