### PR TITLE
AAE-38306 Override image versions with supported ones

### DIFF
--- a/helm/alfresco-process-infrastructure/README.md
+++ b/helm/alfresco-process-infrastructure/README.md
@@ -602,6 +602,7 @@ Kubernetes: `>=1.15.0-0`
 | alfresco-process-analytics-service.service.internalPort | int | `8080` |  |
 | alfresco-process-analytics-service.service.name | string | `"alfresco-process-analytics-service"` |  |
 | alfresco-rabbitmq.image.repository | string | `"bitnamilegacy/rabbitmq"` |  |
+| alfresco-rabbitmq.image.tag | string | `"3.8.9"` |  |
 | alfresco-rds.image.repository | string | `"bitnamilegacy/postgresql"` |  |
 | alfresco-static-resources.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels."app.kubernetes.io/instance" | string | `"{{ .Release.Name }}"` |  |
 | alfresco-static-resources.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels."app.kubernetes.io/name" | string | `"{{ template \"common.name\" . }}"` |  |

--- a/helm/alfresco-process-infrastructure/values.yaml
+++ b/helm/alfresco-process-infrastructure/values.yaml
@@ -1768,3 +1768,4 @@ alfresco-rds:
 alfresco-rabbitmq:
   image:
     repository: bitnamilegacy/rabbitmq
+    tag: 3.8.9


### PR DESCRIPTION
To install RabbitMQ, version `14.4.4` of the Helm chart is being used   https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami/index.yaml which points to version `3.13.3-debian-12-r0` of the Docker image, which is causing some problems on the APA release. So this change overwrites the rabbitmq image using a supported one. 