### PR TITLE
OPSEXP-3726 Add missing use-regex ingress annotation for Traefik compatibility

### DIFF
--- a/helm/alfresco-process-infrastructure/README.md
+++ b/helm/alfresco-process-infrastructure/README.md
@@ -150,6 +150,7 @@ Kubernetes: `>=1.15.0-0`
 | alfresco-identity-adapter-service.image.repository | string | `"quay.io/alfresco/alfresco-identity-adapter-service"` |  |
 | alfresco-identity-adapter-service.image.tag | string | `"7.21.0-alpha.2"` |  |
 | alfresco-identity-adapter-service.ingress.annotations."nginx.ingress.kubernetes.io/rewrite-target" | string | `"/$1"` |  |
+| alfresco-identity-adapter-service.ingress.annotations."nginx.ingress.kubernetes.io/use-regex" | string | `"true"` |  |
 | alfresco-identity-adapter-service.ingress.className | string | `"nginx"` |  |
 | alfresco-identity-adapter-service.ingress.enabled | bool | `true` |  |
 | alfresco-identity-adapter-service.ingress.path | string | `"/identity-adapter-service/?(.*)"` |  |
@@ -484,6 +485,7 @@ Kubernetes: `>=1.15.0-0`
 | alfresco-modeling-service.image.repository | string | `"quay.io/alfresco/alfresco-modeling-service"` |  |
 | alfresco-modeling-service.image.tag | string | `"7.21.0-alpha.2"` |  |
 | alfresco-modeling-service.ingress.annotations."nginx.ingress.kubernetes.io/rewrite-target" | string | `"/$1"` |  |
+| alfresco-modeling-service.ingress.annotations."nginx.ingress.kubernetes.io/use-regex" | string | `"true"` |  |
 | alfresco-modeling-service.ingress.className | string | `"nginx"` |  |
 | alfresco-modeling-service.ingress.enabled | bool | `true` |  |
 | alfresco-modeling-service.ingress.path | string | `""` |  |

--- a/helm/alfresco-process-infrastructure/values.yaml
+++ b/helm/alfresco-process-infrastructure/values.yaml
@@ -534,6 +534,7 @@ alfresco-modeling-service:
     className: nginx
     annotations:
       nginx.ingress.kubernetes.io/rewrite-target: /$1
+      nginx.ingress.kubernetes.io/use-regex: "true"
     path: ""
     subPaths:
       - /modeling-service/?(.*)
@@ -1615,6 +1616,7 @@ alfresco-identity-adapter-service:
     className: nginx
     annotations:
       nginx.ingress.kubernetes.io/rewrite-target: /$1
+      nginx.ingress.kubernetes.io/use-regex: "true"
     path: "/identity-adapter-service/?(.*)"
     pathType: ImplementationSpecific
   image:


### PR DESCRIPTION
OPSEXP-3726

As part of the ongoing migration from NGINX to Traefik ingress controller, this PR adds the missing `nginx.ingress.kubernetes.io/use-regex: "true"` annotation to ingress definitions that use regex-based path matching.

Traefik's Kubernetes Ingress provider requires the `use-regex` annotation to be explicitly set to "true" to interpret path patterns as regular expressions. Without it, paths containing regex capture groups are treated as literal strings, causing routing failures. While the NGINX ingress controller also officially recommends setting this annotation, it implicitly enables regex location matching (`~`) whenever the `rewrite-target` annotation is present on a given host. Traefik has no such implicit fallback.

https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#use-regex 
> Additionally, if the [rewrite-target annotation](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#rewrite) is used on any Ingress for a given host, then the case insensitive regular expression [location modifier](https://nginx.org/en/docs/http/ngx_http_core_module.html#location) will be enforced on ALL paths for a given host regardless of what Ingress they are defined on.