### PR TITLE
OPSEXP-3726 Add missing use-regex ingress annotation for Traefik compatibility

### DIFF
--- a/.github/workflows/enforce-pr-conventions.yml
+++ b/.github/workflows/enforce-pr-conventions.yml
@@ -19,4 +19,4 @@ jobs:
         id: git-naming-convention
         uses: Alfresco/alfresco-build-tools/.github/actions/enforce-pr-conventions@166e610d3eebb2a561d6daba97cd58d98ef2db14 # v8.13.0
         with:
-          jira-project-key: AAE|HXOR
+          jira-project-key: AAE|HXOR|OPSEXP

--- a/helm/alfresco-process-infrastructure/README.md
+++ b/helm/alfresco-process-infrastructure/README.md
@@ -148,6 +148,7 @@ Kubernetes: `>=1.15.0-0`
 | alfresco-identity-adapter-service.image.repository | string | `"quay.io/alfresco/alfresco-identity-adapter-service"` |  |
 | alfresco-identity-adapter-service.image.tag | string | `"7.19.5-alpha.1"` |  |
 | alfresco-identity-adapter-service.ingress.annotations."nginx.ingress.kubernetes.io/rewrite-target" | string | `"/$1"` |  |
+| alfresco-identity-adapter-service.ingress.annotations."nginx.ingress.kubernetes.io/use-regex" | string | `"true"` |  |
 | alfresco-identity-adapter-service.ingress.className | string | `"nginx"` |  |
 | alfresco-identity-adapter-service.ingress.enabled | bool | `true` |  |
 | alfresco-identity-adapter-service.ingress.path | string | `"/identity-adapter-service/?(.*)"` |  |
@@ -480,6 +481,7 @@ Kubernetes: `>=1.15.0-0`
 | alfresco-modeling-service.image.repository | string | `"quay.io/alfresco/alfresco-modeling-service"` |  |
 | alfresco-modeling-service.image.tag | string | `"7.19.5-alpha.3"` |  |
 | alfresco-modeling-service.ingress.annotations."nginx.ingress.kubernetes.io/rewrite-target" | string | `"/$1"` |  |
+| alfresco-modeling-service.ingress.annotations."nginx.ingress.kubernetes.io/use-regex" | string | `"true"` |  |
 | alfresco-modeling-service.ingress.className | string | `"nginx"` |  |
 | alfresco-modeling-service.ingress.enabled | bool | `true` |  |
 | alfresco-modeling-service.ingress.path | string | `""` |  |

--- a/helm/alfresco-process-infrastructure/values.yaml
+++ b/helm/alfresco-process-infrastructure/values.yaml
@@ -534,6 +534,7 @@ alfresco-modeling-service:
     className: nginx
     annotations:
       nginx.ingress.kubernetes.io/rewrite-target: /$1
+      nginx.ingress.kubernetes.io/use-regex: "true"
     path: ""
     subPaths:
       - /modeling-service/?(.*)
@@ -1587,6 +1588,7 @@ alfresco-identity-adapter-service:
     className: nginx
     annotations:
       nginx.ingress.kubernetes.io/rewrite-target: /$1
+      nginx.ingress.kubernetes.io/use-regex: "true"
     path: "/identity-adapter-service/?(.*)"
     pathType: ImplementationSpecific
   image:


### PR DESCRIPTION
Backport https://github.com/Alfresco/alfresco-process-infrastructure-deployment/pull/5250 https://github.com/Alfresco/alfresco-process-infrastructure-deployment/pull/5251