### PR TITLE
AAE-46783 Sign version propagation commits

### DIFF
--- a/.github/workflows/versions-propagation-auto-merge.yml
+++ b/.github/workflows/versions-propagation-auto-merge.yml
@@ -9,7 +9,7 @@ jobs:
   versions-propagation-auto-merge:
     runs-on: ubuntu-latest
     steps:
-    - uses: Alfresco/alfresco-build-tools/.github/actions/automate-propagation@162d01f0dd3d9ead7526be3b046743fae5afb2cd # v18.0.1
+    - uses: Alfresco/alfresco-build-tools/.github/actions/automate-propagation@4e61fa01622e3f3a1898eb059d9a3af208897515 # v18.9.0
       with:
         auto-merge-token: ${{ secrets.BOT_GITHUB_TOKEN }}
         approval-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Pins the `automate-propagation` action to v18.9.0. Merge side only; no commit signing changes here.

Issue: https://hyland.atlassian.net/browse/AAE-46783